### PR TITLE
Expose peer connection object to parent scope.

### DIFF
--- a/app/callstats-amazon-shim.js
+++ b/app/callstats-amazon-shim.js
@@ -2,10 +2,13 @@
 /*jshint unused:false*/
 
 var SoftphoneErrorTypes = connect.SoftphoneErrorTypes;
+var RTCErrorTypes = connect.RTCErrors;
 
 (function (global) {
-  var CallstatsAmazonShim = function(callstats) {
-    CallstatsAmazonShim.callstats = callstats;
+	var CallstatsAmazonShim = function (callstats) {
+		CallstatsAmazonShim.callstats = callstats;
+		// pc is available in this functional scope
+		var pc = undefined;
 
     function subscribeToAmazonContactEvents(contact) {
       CallstatsAmazonShim.remoteId = contact.getActiveInitialConnection().getEndpoint().phoneNumber + "";
@@ -26,7 +29,7 @@ var SoftphoneErrorTypes = connect.SoftphoneErrorTypes;
       if (!error) {
         return;
       }
-      var confId = localId + ":" + remoteId;
+	  var confId = localId + ":" + (CallstatsAmazonShim.remoteId || localId);
       if (error.errorType === SoftphoneErrorTypes.MICROPHONE_NOT_SHARED) {
         CallstatsAmazonShim.callstats.reportError(null, confId, CallstatsAmazonShim.callstats.webRTCFunctions.getUserMedia, error);
       } else if (error.errorType === SoftphoneErrorTypes.SIGNALLING_CONNECTION_FAILURE) {
@@ -35,12 +38,18 @@ var SoftphoneErrorTypes = connect.SoftphoneErrorTypes;
         CallstatsAmazonShim.callstats.reportError(pc, confId, CallstatsAmazonShim.callstats.webRTCFunctions.setLocalDescription, error);
       } else if (error.errorType === SoftphoneErrorTypes.ICE_COLLECTION_TIMEOUT) {
         CallstatsAmazonShim.callstats.reportError(pc, confId, CallstatsAmazonShim.callstats.webRTCFunctions.iceConnectionFailure, error);
-      }
+      } else if (error.errorType === SoftphoneErrorTypes.WEBRTC_ERROR) {
+		  switch(error.endPointUrl) {
+			  case RTCErrorTypes.SET_REMOTE_DESCRIPTION_FAILURE:
+				  CallstatsAmazonShim.callstats.reportError(pc, confId, CallstatsAmazonShim.callstats.webRTCFunctions.setRemoteDescription, error);
+				  break;
+		  }
+	  }
     }
 
     function handleSessionCreated(session) {
       var confId = CallstatsAmazonShim.localUserID + ":" + CallstatsAmazonShim.remoteId;
-      var pc = session._pc;
+      pc = session._pc;
       try {
         CallstatsAmazonShim.callstats.addNewFabric(pc, CallstatsAmazonShim.remoteId, CallstatsAmazonShim.callstats.fabricUsage.multiplex, confId);
       } catch(error) {

--- a/app/callstats-amazon-shim.js
+++ b/app/callstats-amazon-shim.js
@@ -5,10 +5,10 @@ var SoftphoneErrorTypes = connect.SoftphoneErrorTypes;
 var RTCErrorTypes = connect.RTCErrors;
 
 (function (global) {
-	var CallstatsAmazonShim = function (callstats) {
-		CallstatsAmazonShim.callstats = callstats;
-		// pc is available in this functional scope
-		var pc = undefined;
+  var CallstatsAmazonShim = function(callstats) {
+    CallstatsAmazonShim.callstats = callstats;
+    // pc is available in this functional scope
+    var pc = undefined;
 
     function subscribeToAmazonContactEvents(contact) {
       CallstatsAmazonShim.remoteId = contact.getActiveInitialConnection().getEndpoint().phoneNumber + "";
@@ -29,7 +29,7 @@ var RTCErrorTypes = connect.RTCErrors;
       if (!error) {
         return;
       }
-	  var confId = localId + ":" + (CallstatsAmazonShim.remoteId || localId);
+      var confId = localId + ":" + (CallstatsAmazonShim.remoteId || localId);
       if (error.errorType === SoftphoneErrorTypes.MICROPHONE_NOT_SHARED) {
         CallstatsAmazonShim.callstats.reportError(null, confId, CallstatsAmazonShim.callstats.webRTCFunctions.getUserMedia, error);
       } else if (error.errorType === SoftphoneErrorTypes.SIGNALLING_CONNECTION_FAILURE) {


### PR DESCRIPTION
https://app.clubhouse.io/callstatsio/story/11439/expose-pc-to-parent-function-scope

- [x] Expose the peer connection object to parent function scope so that child function(s) can access pc object.
- [x] Remote ID might not generate for early error(s). For example, getUserMedia error can fire before a session is created. In those case ```confId``` will use localId instead of ```undefined``` remote id